### PR TITLE
fix(lighthouse_network): use where clause for `Behaviour`

### DIFF
--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -63,7 +63,3 @@ quickcheck_macros = "0.9.1"
 [features]
 libp2p-websocket = []
 libp2p-nym = []
-
-[patch.crates-io] 
-libp2p = { git = "https://github.com/ChainSafe/rust-libp2p.git", rev = "e3440d25681df380c9f0f8cfdcfd5ecc0a4f2fb6" }
-multiaddr = { git = "https://github.com/ChainSafe/rust-multiaddr.git", rev = "2d21365f880622adf1c8e594b72e671dbac9dd64" }

--- a/beacon_node/lighthouse_network/src/service/behaviour.rs
+++ b/beacon_node/lighthouse_network/src/service/behaviour.rs
@@ -16,7 +16,11 @@ pub type SubscriptionFilter = MaxCountSubscriptionFilter<WhitelistSubscriptionFi
 pub type Gossipsub = BaseGossipsub;
 
 #[derive(NetworkBehaviour)]
-pub(crate) struct Behaviour<AppReqId: ReqId, TSpec: EthSpec> {
+pub(crate) struct Behaviour<AppReqId, TSpec>
+where
+    AppReqId: ReqId,
+    TSpec: EthSpec
+{
     /// The routing pub-sub mechanism for eth2.
     pub gossipsub: Gossipsub,
     /// The Eth2 RPC specified in the wire-0 protocol.


### PR DESCRIPTION
https://github.com/libp2p/rust-libp2p/issues/2879#issuecomment-1241538171

https://github.com/chainSafe/rust-libp2p uses an advance version of libp2p which has removed the support for previous syntax, switching to where clause resolves the current compilation problem