### PR TITLE
feat(scripts/local_testnet): sleep 10s after starting nym clients

### DIFF
--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -44,7 +44,7 @@ prometheus-client = "0.19"
 unused_port = { path = "../../common/unused_port" }
 delay_map = "0.3.0"
 void = "1"
-rust-libp2p-nym = { git = "https://github.com/ChainSafe/rust-libp2p-nym.git", rev = "7f4f8d3ee9a323ab3422b9b951c8b87fdc6854da" }
+rust-libp2p-nym = { git = "https://github.com/ChainSafe/rust-libp2p-nym.git", rev = "a5cd52bb1107d2febe9741ea2caa919671b75e7c" }
 
 [dependencies.libp2p]
 version = "0.51.0"

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -120,6 +120,7 @@ for (( bn=1; bn<=$BN_COUNT; bn++ )); do
     execute_command_add_PID nym_client_$bn.log \
         ./nym_client.sh $((BN_nym_client_base + $bn))
 done
+sleeping 10
 
 # start beacon clients
 for (( bn=1; bn<=$BN_COUNT; bn++ )); do


### PR DESCRIPTION
- [x] use latest rust-libp2p-nym
- [x] sleep after starting nym clients


to verify the local_testnet

```bash
cargo install nym-client --git https://github.com/nymtech/nym.git
npm i ganache --global

make install
make instal-lcli
cd scripts/local_testnet

# term-1
./ganache_test_node.sh

# term-2
./start_local_testnet

# term-3
tail -f ~/.lighthouse/local-testnet/testnet/beacon_node_1.log # check if everything works

curl http://localhost:6001/metrics # verify the metrics are working
```
