### PR TITLE
feat(logs): enable logging for rust-libp2p-nym

### DIFF
--- a/scripts/local_testnet/beacon_node.sh
+++ b/scripts/local_testnet/beacon_node.sh
@@ -43,8 +43,10 @@ metrics_port=${@:$OPTIND+3:1}
 nym_client_port=${@:$OPTIND+4:1}
 
 exec env NYM_CLIENT="ws://0.0.0.0:${nym_client_port}" \
+    env RUST_LOG=rust_libp2p_nym=DEBUG \
     lighthouse \
 	--debug-level $DEBUG_LEVEL \
+    -l \
 	bn \
 	$SUBSCRIBE_ALL_SUBNETS \
 	--datadir $data_dir \


### PR DESCRIPTION
- [x] display logs for rust-libp2p-nym for debugging

This pr is a template of enabling the logs of `rust-libp2p-nym` in `lighthouse`

point this dep to the local repo could make the develpoment smoothly xd

https://github.com/ChainSafe/lighthouse/blob/9c2d2051b996223ed548cbc5938276a1aa119368/beacon_node/lighthouse_network/Cargo.toml#L47

```bash
# run local testnet with debug info
./start-local-testnet.sh -d debug
```