### PR TITLE
feat(ln): add libp2p transport flags to config

### DIFF
--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -59,8 +59,3 @@ exit-future = "0.2.0"
 void = "1"
 quickcheck = "0.9.2"
 quickcheck_macros = "0.9.1"
-
-[features]
-default = [ "libp2p-nym", "libp2p-tcp" ]
-libp2p-tcp = []
-libp2p-nym = []

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -7,8 +7,8 @@ use directory::{
 };
 use discv5::{Discv5Config, Discv5ConfigBuilder};
 use libp2p::gossipsub::{
-    FastMessageId, GossipsubConfig, GossipsubConfigBuilder, GossipsubMessage, MessageId,
-    RawGossipsubMessage, ValidationMode,
+    Config as GossipsubConfig, ConfigBuilder as GossipsubConfigBuilder, FastMessageId,
+    Message as GossipsubMessage, MessageId, RawMessage as RawGossipsubMessage, ValidationMode,
 };
 use libp2p::Multiaddr;
 use serde_derive::{Deserialize, Serialize};

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -15,6 +15,7 @@ use serde_derive::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use types::{ForkContext, ForkName};
@@ -53,10 +54,23 @@ pub fn gossip_max_size(is_merge_enabled: bool) -> usize {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Libp2pStrategy {
+pub enum Libp2pTransport {
     Nym,
     Tcp,
-    NymOrTcp,
+    NymEitherTcp,
+}
+
+impl FromStr for Libp2pTransport {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s {
+            "tcp" => Ok(Libp2pTransport::Tcp),
+            "nym" => Ok(Libp2pTransport::Nym),
+            "nym_either_tcp" => Ok(Libp2pTransport::NymEitherTcp),
+            _ => Err(format!("Unknown transport type: {}", s)),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -148,7 +162,7 @@ pub struct Config {
     pub outbound_rate_limiter_config: Option<OutboundRateLimiterConfig>,
 
     /// Configuration for the libp2p strategy.
-    pub libp2p_strategy: Libp2pStrategy,
+    pub libp2p_transport: Libp2pTransport,
 }
 
 impl Config {
@@ -331,7 +345,7 @@ impl Default for Config {
             metrics_enabled: false,
             enable_light_client_server: false,
             outbound_rate_limiter_config: None,
-            libp2p_strategy: Libp2pStrategy::NymOrTcp,
+            libp2p_transport: Libp2pTransport::NymEitherTcp,
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -53,6 +53,13 @@ pub fn gossip_max_size(is_merge_enabled: bool) -> usize {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Libp2pStrategy {
+    Nym,
+    Tcp,
+    NymOrTcp,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 /// Network configuration for lighthouse.
 pub struct Config {
@@ -139,6 +146,9 @@ pub struct Config {
 
     /// Configuration for the outbound rate limiter (requests made by this node).
     pub outbound_rate_limiter_config: Option<OutboundRateLimiterConfig>,
+
+    /// Configuration for the libp2p strategy.
+    pub libp2p_strategy: Libp2pStrategy,
 }
 
 impl Config {
@@ -321,6 +331,7 @@ impl Default for Config {
             metrics_enabled: false,
             enable_light_client_server: false,
             outbound_rate_limiter_config: None,
+            libp2p_strategy: Libp2pStrategy::NymOrTcp,
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/lib.rs
+++ b/beacon_node/lighthouse_network/src/lib.rs
@@ -16,7 +16,7 @@ pub mod peer_manager;
 pub mod rpc;
 pub mod types;
 
-pub use config::gossip_max_size;
+pub use config::{gossip_max_size, Libp2pTransport};
 pub use listen_addr::*;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};

--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -969,6 +969,8 @@ where
         self.current_inbound_substream_id.0 += 1;
     }
 
+    // TODO: remove this function if we don't need it anymore.
+    #[allow(unused)]
     fn inject_dial_upgrade_error(
         &mut self,
         request_info: (Id, OutboundRequest<TSpec>),

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -321,7 +321,7 @@ where
         Poll::Pending
     }
 
-    fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {}
+    fn on_swarm_event(&mut self, _: FromSwarm<Self::ConnectionHandler>) {}
 }
 
 impl<Id, TSpec> slog::KV for RPCMessage<Id, TSpec>

--- a/beacon_node/lighthouse_network/src/service/behaviour.rs
+++ b/beacon_node/lighthouse_network/src/service/behaviour.rs
@@ -1,6 +1,7 @@
 use crate::discovery::Discovery;
 use crate::peer_manager::PeerManager;
 use crate::rpc::{ReqId, RPC};
+use crate::types::SnappyTransform;
 
 use libp2p::gossipsub::subscription_filter::{
     MaxCountSubscriptionFilter, WhitelistSubscriptionFilter,
@@ -14,7 +15,7 @@ use types::EthSpec;
 use super::api_types::RequestId;
 
 pub type SubscriptionFilter = MaxCountSubscriptionFilter<WhitelistSubscriptionFilter>;
-pub type Gossipsub = BaseGossipsub;
+pub type Gossipsub = BaseGossipsub<SnappyTransform, SubscriptionFilter>;
 
 #[derive(NetworkBehaviour)]
 pub(crate) struct Behaviour<AppReqId, TSpec>

--- a/beacon_node/lighthouse_network/src/service/gossipsub_scoring_parameters.rs
+++ b/beacon_node/lighthouse_network/src/service/gossipsub_scoring_parameters.rs
@@ -1,7 +1,8 @@
 use crate::types::{GossipEncoding, GossipKind, GossipTopic};
 use crate::{error, TopicHash};
 use libp2p::gossipsub::{
-    GossipsubConfig, IdentTopic as Topic, PeerScoreParams, PeerScoreThresholds, TopicScoreParams,
+    Config as GossipsubConfig, IdentTopic as Topic, PeerScoreParams, PeerScoreThresholds,
+    TopicScoreParams,
 };
 use std::cmp::max;
 use std::collections::HashMap;

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -23,11 +23,11 @@ use api_types::{PeerRequestId, Request, RequestId, Response};
 use futures::stream::StreamExt;
 use gossipsub_scoring_parameters::{lighthouse_gossip_thresholds, PeerScoreSettings};
 use libp2p::bandwidth::BandwidthSinks;
-use libp2p::gossipsub::error::PublishError;
 use libp2p::gossipsub::metrics::Config as GossipsubMetricsConfig;
 use libp2p::gossipsub::subscription_filter::MaxCountSubscriptionFilter;
+use libp2p::gossipsub::PublishError;
 use libp2p::gossipsub::{
-    GossipsubEvent, IdentTopic as Topic, MessageAcceptance, MessageAuthenticity, MessageId,
+    Event as GossipsubEvent, IdentTopic as Topic, MessageAcceptance, MessageAuthenticity, MessageId,
 };
 use libp2p::identify::{Behaviour as Identify, Config as IdentifyConfig, Event as IdentifyEvent};
 use libp2p::multiaddr::{Multiaddr, Protocol as MProtocol};

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -249,23 +249,13 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
 
             let snappy_transform = SnappyTransform::new(config.gs_config.max_transmit_size());
 
-            // TODO: idk why but this function no longer likes the `filter` and `snappy_transform`
-            // params after upgrading libp2p.
-            // let mut gossipsub = Gossipsub::new_with_subscription_filter_and_transform(
-            //     MessageAuthenticity::Anonymous,
-            //     config.gs_config.clone(),
-            //     Some(gossipsub_metrics),
-            //     filter,
-            //     snappy_transform,
-            // )
-
-            let mut gossipsub = Gossipsub::new_with_metrics(
+            let mut gossipsub = Gossipsub::new_with_subscription_filter_and_transform(
                 MessageAuthenticity::Anonymous,
                 config.gs_config.clone(),
-                gossipsub_metrics.0,
-                gossipsub_metrics.1,
-            )
-            .map_err(|e| format!("Could not construct gossipsub: {:?}", e))?;
+                Some(gossipsub_metrics),
+                filter,
+                snappy_transform,
+            )?;
 
             gossipsub
                 .with_peer_score(params, thresholds)

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1,6 +1,6 @@
 use self::behaviour::Behaviour;
 use self::gossip_cache::GossipCache;
-use crate::config::{gossipsub_config, Libp2pStrategy, NetworkLoad};
+use crate::config::{gossipsub_config, Libp2pTransport, NetworkLoad};
 use crate::discovery::{
     subnet_predicate, DiscoveredPeers, Discovery, FIND_NODE_QUERY_CLOSEST_PEERS,
 };
@@ -321,10 +321,10 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
 
         let (swarm, bandwidth) = {
             // Set up the transport - tcp/ws with noise and mplex
-            let (transport, bandwidth) = match config.libp2p_strategy {
-                Libp2pStrategy::Nym => build_nym_transport(local_keypair.clone()).await,
-                Libp2pStrategy::Tcp => build_tcp_transport(local_keypair.clone()).await,
-                Libp2pStrategy::NymOrTcp => build_transport(local_keypair.clone()).await,
+            let (transport, bandwidth) = match config.libp2p_transport {
+                Libp2pTransport::Nym => build_nym_transport(local_keypair.clone()).await,
+                Libp2pTransport::Tcp => build_tcp_transport(local_keypair.clone()).await,
+                Libp2pTransport::NymEitherTcp => build_transport(local_keypair.clone()).await,
             }
             .map_err(|e| format!("Failed to build transport: {:?}", e))?
             .with_bandwidth_logging();

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -2,7 +2,9 @@
 
 use crate::types::{GossipEncoding, GossipKind, GossipTopic};
 use crate::TopicHash;
-use libp2p::gossipsub::{DataTransform, GossipsubMessage, RawGossipsubMessage};
+use libp2p::gossipsub::{
+    DataTransform, Message as GossipsubMessage, RawMessage as RawGossipsubMessage,
+};
 use snap::raw::{decompress_len, Decoder, Encoder};
 use ssz::{Decode, Encode};
 use std::boxed::Box;

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -261,6 +261,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             .min_values(0)
             .hidden(true)
         )
+        .arg(
+            Arg::with_name("transport")
+            .long("transport")
+            .short("t")
+            .help("specify libp2p transport")
+            .takes_value(true)
+        )
         /* REST API related arguments */
         .arg(
             Arg::with_name("http")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -10,8 +10,8 @@ use environment::RuntimeContext;
 use execution_layer::DEFAULT_JWT_FILE;
 use genesis::Eth1Endpoint;
 use http_api::TlsConfig;
-use lighthouse_network::ListenAddress;
 use lighthouse_network::{multiaddr::Protocol, Enr, Multiaddr, NetworkConfig, PeerIdSerialized};
+use lighthouse_network::{Libp2pTransport, ListenAddress};
 use sensitive_url::SensitiveUrl;
 use slog::{info, warn, Logger};
 use std::cmp;
@@ -757,6 +757,18 @@ pub fn get_config<E: EthSpec>(
     // Payload selection configs
     if cli_args.is_present("always-prefer-builder-payload") {
         client_config.always_prefer_builder_payload = true;
+    }
+
+    if cli_args.is_present("transport") {
+        if let Some(maybe_transport) = cli_args.value_of("transport") {
+            let transport = maybe_transport
+                .parse::<Libp2pTransport>()
+                .map_err(|parse_error| {
+                    format!("Failed to parse transport ({maybe_transport}): {parse_error}")
+                })?;
+
+            client_config.network.libp2p_transport = transport;
+        }
     }
 
     Ok(client_config)

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -112,6 +112,7 @@ BN_udp_tcp_base=9000
 BN_http_port_base=8000
 BN_metrics_port_base=6000
 BN_nym_client_base=1976
+BN_vc_metrics_port_base=5000
 
 (( $VC_COUNT < $BN_COUNT )) && SAS=-s || SAS=
 
@@ -120,7 +121,7 @@ for (( bn=1; bn<=$BN_COUNT; bn++ )); do
     execute_command_add_PID nym_client_$bn.log \
         ./nym_client.sh $((BN_nym_client_base + $bn))
 done
-sleeping 10
+sleeping 60
 
 # start beacon clients
 for (( bn=1; bn<=$BN_COUNT; bn++ )); do
@@ -138,7 +139,8 @@ for (( vc=1; vc<=$VC_COUNT; vc++ )); do
     execute_command_add_PID validator_node_$vc.log ./validator_client.sh \
         $BUILDER_PROPOSALS -d $DEBUG_LEVEL \
         $DATADIR/node_$vc \
-        http://0.0.0.0:$((BN_http_port_base + $vc))
+        http://0.0.0.0:$((BN_http_port_base + $vc)) \
+        $((BN_vc_metrics_port_base + $vc))
 done
 
 echo "Started!"

--- a/scripts/local_testnet/validator_client.sh
+++ b/scripts/local_testnet/validator_client.sh
@@ -29,5 +29,8 @@ exec lighthouse \
 	--datadir ${@:$OPTIND:1} \
 	--testnet-dir $TESTNET_DIR \
 	--init-slashing-protection \
+    --metrics \
 	--beacon-nodes ${@:$OPTIND+1:1} \
+    --metrics-address 0.0.0.0 \
+    --metrics-port ${@:OPTIND+2:1}\
 	$VC_ARGS

--- a/testing/simulator/src/eth1_sim.rs
+++ b/testing/simulator/src/eth1_sim.rs
@@ -145,6 +145,7 @@ pub fn run_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
         beacon_config.eth1.node_far_behind_seconds = 20;
         beacon_config.dummy_eth1_backend = false;
         beacon_config.sync_eth1_chain = true;
+        beacon_config.network.metrics_enabled = true;
         beacon_config.eth1.auto_update_interval_millis = eth1_block_time.as_millis() as u64;
         beacon_config.eth1.chain_id = Eth1Id::from(chain_id);
         beacon_config.network.target_peers = node_count - 1;


### PR DESCRIPTION
## Summary

 - [x] fix gossipsub config
 - [x] update deprecated implementations
 - [x] introduce new config for lighthouse network that can switch libp2p strategy
   - tcp
   - nym
   - tcp or nym
 - [x] build transport via libp2p strategy